### PR TITLE
Deprecation changes

### DIFF
--- a/gabc-output.tex
+++ b/gabc-output.tex
@@ -1,5 +1,5 @@
 \documentclass[11pt]{article}
-\usepackage[deprecated=false,###DEBUG###]{gregoriotex}
+\usepackage[deprecated=false###DEBUG###]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ###FONTDIR### ,

--- a/gabc-output.tex
+++ b/gabc-output.tex
@@ -1,5 +1,5 @@
 \documentclass[11pt]{article}
-\usepackage###DEBUG###{gregoriotex}
+\usepackage[deprecated=false,###DEBUG###]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ###FONTDIR### ,

--- a/harness.sh
+++ b/harness.sh
@@ -387,7 +387,7 @@ function gabc_output_test {
         then
             debugarg=''
         else
-            debugarg="[debug=$GABC_OUTPUT_DEBUG]"
+            debugarg=",debug=$GABC_OUTPUT_DEBUG"
         fi
         if ${SED} -e "s/###FILENAME###/$filebase/" \
             -e "s/###DEBUG###/$debugarg/" \

--- a/tests/plain-tex/PopulusSion/PopulusSion.tex
+++ b/tests/plain-tex/PopulusSion/PopulusSion.tex
@@ -1,6 +1,7 @@
 \pdfpagewidth210mm
 \pdfpageheight297mm
 \input gregoriotex
+\gre@deprecatedfalse
 \grechangedim{afterinitialshift}{2.2mm}{1}
 \grechangedim{beforeinitialshift}{2.2mm}{1}
 \font\alegreya = [../../../fonts/Alegreya-Regular.otf] at 12pt\relax

--- a/tests/plain-tex/braces/over_braces.tex
+++ b/tests/plain-tex/braces/over_braces.tex
@@ -1,6 +1,7 @@
 \pdfpagewidth210mm
 \pdfpageheight297mm
 \input gregoriotex
+\gre@deprecatedfalse
 \font\alegreya = [../../../fonts/Alegreya-Regular.otf] at 12pt\relax
 \alegreya
 \gregorioscore[a]{over_braces}

--- a/tests/tex-output/Dominican-neumes/Dominican-neumes.tex
+++ b/tests/tex-output/Dominican-neumes/Dominican-neumes.tex
@@ -4,7 +4,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/PopulusSion/PopulusSion.tex
+++ b/tests/tex-output/PopulusSion/PopulusSion.tex
@@ -10,7 +10,7 @@
 \usepackage{graphicx} % support the \includegraphics command and options
 \usepackage{geometry} % See geometry.pdf to learn the layout options. There are lots.
 \geometry{a4paper} % or letterpaper (US) or a5paper or....
-\usepackage{gregoriotex} % for gregorio score inclusion
+\usepackage[deprecated=false]{gregoriotex} % for gregorio score inclusion
 \usepackage{fullpage} % to reduce the margins
 \setmainfont[
     Path = ../../../fonts/ ,
@@ -38,8 +38,8 @@
 \grechangedim{beforeinitialshift}{2.2mm}{1}
 
 % Here we set the initial font. Change 43 if you want a bigger initial.
-\def\greinitialformat#1{%
-{\fontsize{43}{43}\selectfont #1}%
+\grechangestyle{initial}{%
+\fontsize{43}{43}\selectfont%
 }
 
 % We set red lines here, comment it if you want black ones.

--- a/tests/tex-output/SalveReginaOP/SalveReginaOP.tex
+++ b/tests/tex-output/SalveReginaOP/SalveReginaOP.tex
@@ -4,7 +4,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage[debug={eolshift,general}]{gregoriotex}
+\usepackage[debug={eolshift,general},deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/bugs/fix-396/fix-396.tex
+++ b/tests/tex-output/bugs/fix-396/fix-396.tex
@@ -1,6 +1,6 @@
 \documentclass[a3paper,fontsize=42pt,DIV=17]{scrartcl}
 
-\usepackage[autocompile]{gregoriotex}
+\usepackage[autocompile,deprecated=false]{gregoriotex}
 \usepackage{libertine}
 \pagestyle{empty}
 \grechangestaffsize{29}

--- a/tests/tex-output/bugs/fix-43/fix-43.tex
+++ b/tests/tex-output/bugs/fix-43/fix-43.tex
@@ -1,5 +1,5 @@
 \documentclass[11pt]{article}
-\usepackage[debug=all]{gregoriotex}
+\usepackage[debug=all,deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,

--- a/tests/tex-output/bugs/fix-508/fix-508.tex
+++ b/tests/tex-output/bugs/fix-508/fix-508.tex
@@ -1,6 +1,6 @@
 \documentclass[a5paper,11pt,DIV=17]{scrartcl}
 
-\usepackage[autocompile]{gregoriotex}
+\usepackage[autocompile,deprecated=false]{gregoriotex}
 \usepackage{libertine}
 \usepackage{calc}
 \pagestyle{empty}
@@ -9,7 +9,7 @@
 \makeatletter
 \setlength\tmpsize{\gre@factor pt}
 \makeatother
-\def\greinitialformat#1{{\fontsize{2.5\tmpsize}{2.5\tmpsize}\selectfont #1}}
+\grechangestyle{initial}{\fontsize{2.5\tmpsize}{2.5\tmpsize}\selectfont}
 
 \begin{document}
 

--- a/tests/tex-output/bugs/fix-592/fix-592.tex
+++ b/tests/tex-output/bugs/fix-592/fix-592.tex
@@ -3,7 +3,7 @@
 %issue: 592
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage[forcecompile]{gregoriotex}
+\usepackage[forcecompile,deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,

--- a/tests/tex-output/bugs/fix-595/fix-595.tex
+++ b/tests/tex-output/bugs/fix-595/fix-595.tex
@@ -1,7 +1,7 @@
 % !TEX TS-program = LuaLaTeX+se
 \documentclass[11pt]{article}
 
-\usepackage[autocompile]{gregoriotex}
+\usepackage[autocompile,deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,

--- a/tests/tex-output/bugs/fix-60/fix-60.tex
+++ b/tests/tex-output/bugs/fix-60/fix-60.tex
@@ -2,7 +2,7 @@
 %notes: a' and b' were not increasing the space below the staff
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,

--- a/tests/tex-output/change-glyph/change-glyph.tex
+++ b/tests/tex-output/change-glyph/change-glyph.tex
@@ -4,7 +4,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,
@@ -29,8 +29,8 @@
 \grechangedim{afterinitialshift}{2.2mm}{1}
 \grechangedim{beforeinitialshift}{2.2mm}{1}
 
-\def\greinitialformat#1{%
-{\fontsize{43}{43}\selectfont #1}%
+\grechangestyle{initial}{%
+\fontsize{43}{43}\selectfont%
 }
 
 \gresetlinecolor{gregoriocolor}

--- a/tests/tex-output/firsts/firsts.tex
+++ b/tests/tex-output/firsts/firsts.tex
@@ -1,7 +1,7 @@
 %notes: tests first word/syllable styling
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/illumination/illumination.tex
+++ b/tests/tex-output/illumination/illumination.tex
@@ -5,7 +5,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage[forcecompile]{gregoriotex}
+\usepackage[forcecompile,deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/lineshifts/lineshifts.tex
+++ b/tests/tex-output/lineshifts/lineshifts.tex
@@ -10,7 +10,7 @@
 \usepackage{graphicx} % support the \includegraphics command and options
 \usepackage{geometry} % See geometry.pdf to learn the layout options. There are lots.
 \geometry{a4paper} % or letterpaper (US) or a5paper or....
-\usepackage[debug={bolshift,eolshift,general}]{gregoriotex} % for gregorio score inclusion
+\usepackage[debug={bolshift,eolshift,general},deprecated=false]{gregoriotex} % for gregorio score inclusion
 \usepackage{fullpage} % to reduce the margins
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/lyric-centering/lyric-centering.tex
+++ b/tests/tex-output/lyric-centering/lyric-centering.tex
@@ -1,7 +1,7 @@
 %notes: tests lyric centering
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/sample/sample.tex
+++ b/tests/tex-output/sample/sample.tex
@@ -2,7 +2,7 @@
 %notes: sample
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/sign-styles/sign-styles.tex
+++ b/tests/tex-output/sign-styles/sign-styles.tex
@@ -4,7 +4,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,
@@ -25,8 +25,8 @@
 \grechangedim{afterinitialshift}{2.2mm}{1}
 \grechangedim{beforeinitialshift}{2.2mm}{1}
 
-\def\greinitialformat#1{%
-{\fontsize{43}{43}\selectfont #1}%
+\grechangestyle{initial}{%
+\fontsize{43}{43}\selectfont%
 }
 
 \gresetlinecolor{gregoriocolor}

--- a/tests/tex-output/snippet/snippet.tex
+++ b/tests/tex-output/snippet/snippet.tex
@@ -1,7 +1,7 @@
 \documentclass[11pt,a4paper]{article}
 
 \usepackage{fontspec}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,
@@ -22,8 +22,8 @@
 \grechangedim{afterinitialshift}{2.2mm}{1}
 \grechangedim{beforeinitialshift}{2.2mm}{1}
 
-\def\greinitialformat#1{%
-{\fontsize{43}{43}\selectfont #1}%
+\grechangestyle{initial}{%
+\fontsize{43}{43}\selectfont%
 }
 
 \gresetlinecolor{gregoriocolor}

--- a/tests/tex-output/switch-braces/switch-braces.tex
+++ b/tests/tex-output/switch-braces/switch-braces.tex
@@ -4,7 +4,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,
@@ -25,8 +25,8 @@
 \grechangedim{afterinitialshift}{2.2mm}{1}
 \grechangedim{beforeinitialshift}{2.2mm}{1}
 
-\def\greinitialformat#1{%
-{\fontsize{43}{43}\selectfont #1}%
+\grechangestyle{initial}{%
+\fontsize{43}{43}\selectfont%
 }
 
 \gresetlinecolor{gregoriocolor}

--- a/tests/tex-output/symbols-only/symbols-only.tex
+++ b/tests/tex-output/symbols-only/symbols-only.tex
@@ -3,7 +3,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \usepackage{libertine}
 
@@ -21,7 +21,7 @@
 
 \Rbar{}evision
 
-\gresep{2}{20}
+\greseparator{2}{20}
 
 \gredefsizedsymbol{greVBar}{greextra}{VBar.alt}
 \gredefsizedsymbol{greRBar}{greextra}{RBar.alt}
@@ -38,7 +38,7 @@
 
 \Rbar{}evision
 
-\gresep{5}{30}
+\greseparator{5}{30}
 
 \gredefsizedsymbol{greVBar}{greextra}{VBar}
 \gredefsizedsymbol{greRBar}{greextra}{RBar}

--- a/tests/tex-output/symbols/symbols.tex
+++ b/tests/tex-output/symbols/symbols.tex
@@ -4,7 +4,7 @@
 \usepackage{graphicx}
 \usepackage{geometry}
 \geometry{a4paper}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fullpage}
 \setmainfont[
     Path = ../../../fonts/ ,
@@ -25,8 +25,8 @@
 \grechangedim{afterinitialshift}{2.2mm}{1}
 \grechangedim{beforeinitialshift}{2.2mm}{1}
 
-\def\greinitialformat#1{%
-{\fontsize{43}{43}\selectfont #1}%
+\grechangestyle{initial}{%
+\fontsize{43}{43}\selectfont%
 }
 
 \gresetlinecolor{gregoriocolor}
@@ -39,7 +39,7 @@
 
 \gregorioscore[a]{symbols}
 
-\gresep{2}{20}
+\greseparator{2}{20}
 
 \gredefsizedsymbol{greVBar}{greextra}{VBar.alt}
 \gredefsizedsymbol{greRBar}{greextra}{RBar.alt}
@@ -55,7 +55,7 @@
 
 \gregorioscore[a]{symbols}
 
-\gresep{5}{30}
+\greseparator{5}{30}
 
 \gredefsizedsymbol{greVBar}{greextra}{VBar}
 \gredefsizedsymbol{greRBar}{greextra}{RBar}

--- a/tests/tex-output/translation/translation.tex
+++ b/tests/tex-output/translation/translation.tex
@@ -1,7 +1,7 @@
 %notes: test for trnslation centering
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../fonts/ ,

--- a/tests/tex-output/variable-height/variable-height.tex
+++ b/tests/tex-output/variable-height/variable-height.tex
@@ -1,7 +1,7 @@
 %notes: test for trnslation centering
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage{gregoriotex}
+\usepackage[deprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../fonts/ ,


### PR DESCRIPTION
It makes more sense to me if the tests use the stricter deprecation standard (i.e. where they raise errors rather than warnings).  In this way we'll notice the tests where there are deprecation changes sooner.
I've also modified the tests that failed under the newer, stricter standard so that they can pass.