### PR TITLE
Missed changing `deprecated` in a few tests

### DIFF
--- a/tests/tex-output/bugs/fix-396/fix-396.tex
+++ b/tests/tex-output/bugs/fix-396/fix-396.tex
@@ -1,6 +1,6 @@
 \documentclass[a3paper,fontsize=42pt,DIV=17]{scrartcl}
 
-\usepackage[autocompile,deprecated=false]{gregoriotex}
+\usepackage[autocompile,allowdeprecated=false]{gregoriotex}
 \usepackage{libertine}
 \pagestyle{empty}
 \grechangestaffsize{29}

--- a/tests/tex-output/bugs/fix-43/fix-43.tex
+++ b/tests/tex-output/bugs/fix-43/fix-43.tex
@@ -1,5 +1,5 @@
 \documentclass[11pt]{article}
-\usepackage[debug=all,deprecated=false]{gregoriotex}
+\usepackage[debug=all,allowdeprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,

--- a/tests/tex-output/bugs/fix-508/fix-508.tex
+++ b/tests/tex-output/bugs/fix-508/fix-508.tex
@@ -1,6 +1,6 @@
 \documentclass[a5paper,11pt,DIV=17]{scrartcl}
 
-\usepackage[autocompile,deprecated=false]{gregoriotex}
+\usepackage[autocompile,allowdeprecated=false]{gregoriotex}
 \usepackage{libertine}
 \usepackage{calc}
 \pagestyle{empty}

--- a/tests/tex-output/bugs/fix-592/fix-592.tex
+++ b/tests/tex-output/bugs/fix-592/fix-592.tex
@@ -3,7 +3,7 @@
 %issue: 592
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage[forcecompile,deprecated=false]{gregoriotex}
+\usepackage[forcecompile,allowdeprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,

--- a/tests/tex-output/bugs/fix-595/fix-595.tex
+++ b/tests/tex-output/bugs/fix-595/fix-595.tex
@@ -1,7 +1,7 @@
 % !TEX TS-program = LuaLaTeX+se
 \documentclass[11pt]{article}
 
-\usepackage[autocompile,deprecated=false]{gregoriotex}
+\usepackage[autocompile,allowdeprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,

--- a/tests/tex-output/bugs/fix-60/fix-60.tex
+++ b/tests/tex-output/bugs/fix-60/fix-60.tex
@@ -2,7 +2,7 @@
 %notes: a' and b' were not increasing the space below the staff
 \documentclass[11pt]{article}
 \usepackage{graphicx}
-\usepackage[deprecated=false]{gregoriotex}
+\usepackage[allowdeprecated=false]{gregoriotex}
 \usepackage{fontspec}
 \setmainfont[
     Path = ../../../../fonts/ ,


### PR DESCRIPTION
Because these tests are deeper in the file tree than the others, my scripting to change `deprecated` to `allowdeprecated` missed them