### PR TITLE
GregorioTeX's aux file has the extension gaux, not greaux

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -394,7 +394,7 @@ function gabc_output_test {
             -e "s!###FONTDIR###!$testroot/fonts/!" \
             "$testroot/gabc-output.tex" >${texfile}
         then
-            typeset_and_compare "$indir" "$outdir" "$texfile" latexmk -e 'push @generated_exts, "greaux";' -pdf -pdflatex='lualatex --shell-escape'
+            typeset_and_compare "$indir" "$outdir" "$texfile" latexmk -e 'push @generated_exts, "gaux";' -pdf -pdflatex='lualatex --shell-escape'
         else
             fail "Failed to create TeX file" \
                 "Could not create $indir/$outdir/$texfile"
@@ -453,7 +453,7 @@ function tex_output_test {
 
     if cd "$indir" && mkdir "$outdir"
     then
-        typeset_and_compare "$indir" "$outdir" "$filename" latexmk -e 'push @generated_exts, "greaux";' -pdf -pdflatex='lualatex --shell-escape'
+        typeset_and_compare "$indir" "$outdir" "$filename" latexmk -e 'push @generated_exts, "gaux";' -pdf -pdflatex='lualatex --shell-escape'
     else
         fail "Failed to create directory" "Could not create $indir/$outdir"
     fi


### PR DESCRIPTION
I changed this somewhere in the texrenaming process, but didn't notice that the old extension was referenced here until now.