### PR TITLE
Make default action modifiable

### DIFF
--- a/review-results.sh
+++ b/review-results.sh
@@ -25,7 +25,7 @@ do
     IFS='|' read result filename category <<<$line
     if [ "$result" = "FAIL" ]
     then
-        action="-d"
+        action=${ACTION:--d}
         while :
         do
             ./gregorio-test.sh $action "$filename"


### PR DESCRIPTION
This allows the default (i.e. initial) action for each test to be picked up from an environment variable.  Useful for when you need to look at a lot of test results but don't necessarily want to start with their diffs.