### PR TITLE
Bypassed uninstall-gtex.sh generation when running tests.

### DIFF
--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -396,7 +396,7 @@ test|retest)
 
         if ! (cd "$gregorio_dir" && TEXHASH="texhash $TEXMFHOME" \
             CP="rsync -Lci" SKIP=docs,examples,font-sources \
-            ./install-gtex.sh user)
+            GENERATE_UNINSTALL=false ./install-gtex.sh user)
         then
             echo "Unable to install GregorioTeX to $TEXMFHOME" >&2
             exit 8


### PR DESCRIPTION
Running gregorio-test using a not-installed gregorio will generate a spurious uninstall-gtex.sh if using a version of gregorio that can generate the uninstall manifest.  This change prevents that.

Requires gregorio-project/gregorio#1221.

Please review and merge if satisfactory.