### PR TITLE
Added support for lua-module-cache-manager.

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -607,7 +607,8 @@ function gabc_output_test {
             "$testroot/gabc-output.tex" >${texfile}
         then
             typeset_and_compare "$indir" "$outdir" "$texfile" \
-                latexmk -e 'push @generated_exts, "gaux";' -pdf -pdflatex="$PDFLATEX"
+                latexmk -e 'push @generated_exts, "gaux";' -pdf \
+                -pdflatex="$PDFLATEX"
         else
             fail "Failed to create TeX file" \
                 "Could not create $indir/$outdir/$texfile"
@@ -668,7 +669,8 @@ function tex_output_test {
     if cd "$indir" && mkdir "$outdir"
     then
         typeset_and_compare "$indir" "$outdir" "$filename" \
-            latexmk -e 'push @generated_exts, "gaux";' -pdf -pdflatex="$PDFLATEX"
+            latexmk -e 'push @generated_exts, "gaux";' -pdf \
+            -pdflatex="$PDFLATEX"
     else
         fail "Failed to create directory" "Could not create $indir/$outdir"
     fi
@@ -714,7 +716,7 @@ function plain_tex_run {
     do
         echo "=============================================="
         echo "RUN : $count"
-        luatex --shell-escape "$@"
+        eval luatex --shell-escape $LUA_MODULE_CACHE_MANAGER "$@"
     done
     test -f "$LOGFILE" && ! grep -q "Rerun to " "$LOGFILE"
 }

--- a/run-lualatex.sh
+++ b/run-lualatex.sh
@@ -23,6 +23,6 @@ CP="${CP:-cp}"
 
 output="$1"
 shift
-lualatex --shell-escape --debug-format --interaction=nonstopmode --halt-on-error --file-line-error "$@"
+lualatex --shell-escape --debug-format --interaction=nonstopmode --halt-on-error --file-line-error $LUA_MODULE_CACHE_MANAGER "$@"
 #"$CP" --preserve=timestamps --backup=numbered "$output" "${output%.pdf}.backup.pdf"
 #"$CP" --preserve=timestamps --backup=numbered "${output%.pdf}.log" "${output%.pdf}.backup.log"

--- a/tests/cache-manager/prime-cache.tex
+++ b/tests/cache-manager/prime-cache.tex
@@ -1,0 +1,20 @@
+\documentclass[11pt]{article}
+\usepackage{graphicx}
+\usepackage{fontspec}
+\usepackage[allowdeprecated=false]{gregoriotex}
+\setmainfont[
+    Path = ../../fonts/ ,
+    Extension = .otf ,
+    UprightFont = *-Regular ,
+    UprightFeatures = { SmallCapsFont = *SC-Regular } ,
+    BoldFont = *-Bold ,
+    BoldFeatures = { SmallCapsFont = *SC-Bold } ,
+    ItalicFont = *-Italic ,
+    ItalicFeatures = { SmallCapsFont = *SC-Italic } ,
+    BoldItalicFont = *-BoldItalic ,
+    BoldItalicFeatures = { SmallCapsFont = *SC-BoldItalic } ,
+    Ligatures = TeX
+]{Alegreya}
+\begin{document}
+Cache priming
+\end{document}


### PR DESCRIPTION
Fixes #155.

@rpspringuel Please try if this helps things on your computer.  You will need to clone https://github.com/kalrish/luatex-lua-module-cache-manager somewhere and then run ...

> `gregorio-test.sh -M /path/to/lua-module-cache-manager.lua`

... along with whatever other arguments you need.

On my computer, using the cache manager has zero effect.  Runs with and without the cache manager are within 3 seconds of each other, with either beating the other about 50% on any given run.

I may be running it incorrectly, but the cache file is created and updated during the run.
