### PR TITLE
Use `$gregorio` when checking to see that executable is working properly

### DIFF
--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -407,7 +407,7 @@ test|retest)
 
     export gregorio=gregorio-$gregorio_version
 
-    if ! gregorio -F dump -S -s </dev/null 2>/dev/null | grep -q 'SCORE INFOS'
+    if ! $gregorio -F dump -S -s </dev/null 2>/dev/null | grep -q 'SCORE INFOS'
     then
         echo "Gregorio is not installed properly or is not statically linked" >&2
         echo "When building, use ./configure --enable-all-static" >&2


### PR DESCRIPTION
We need to use the variable so that the version number gets tacked on properly, allowing us to check the correct executable.