### PR TITLE
Add option to skip image cache

### DIFF
--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -88,11 +88,12 @@ mode=test
 show_success=false
 long_tests=false
 use_valgrind=false
+skip_cache=false
 declare -A tests_to_run
 while (( $# > 0 ))
 do
     unset OPTIND
-    while getopts ":acCdD:eg:GhlLnPrSv" opt
+    while getopts ":acCdD:eg:GhilLnPrSv" opt
     do
         case $opt in
         a)
@@ -131,6 +132,9 @@ do
             ;;
         h)
             usage=true
+            ;;
+        i)
+            skip_cache=true
             ;;
         l)
             mode=view_log
@@ -263,6 +267,8 @@ Options:
 
   -S                show successful tests.  Default is to show only failed
                     tests.
+
+  -i                do not use cached images when running comparisons
 
   -h                shows this usage message.
 

--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -278,7 +278,7 @@ EOT
     exit 2
 fi
 
-export verify clean_passed
+export verify clean_passed skip_cache
 
 if $color
 then

--- a/harness.sh
+++ b/harness.sh
@@ -484,7 +484,7 @@ function typeset_and_compare {
         else
             if $verify "$texfile"
             then
-                if [[ "$pdffile" -nt "$IMAGE_CACHE/$indir/$outdir" ]]
+                if $skip_cache || [[ "$pdffile" -nt "$IMAGE_CACHE/$indir/$outdir" ]]
                 then
                     rm -fr "$IMAGE_CACHE/$indir/$outdir" && \
                     mkdir -p "$IMAGE_CACHE/$indir/$outdir" && \


### PR DESCRIPTION
This option allows one to skip the image cache when testing (regenerating the skipped image in the process).  It's faster than finding and deleting a particular image (or set of images) from the cache, but is non-selective: all tests being run will skip the image cache.
