### PR TITLE
Define number of processors

### DIFF
--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -53,9 +53,11 @@ then
     source $rcfile
 fi
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
+if [[ "$OSTYPE" == "linux-gnu" ]]
+then
 	export NPROCESSORS="${NPROCESSORS:-$(nproc)}"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+elif [[ "$OSTYPE" == "darwin"* ]]
+then
 	export NPROCESSORS="${NPROCESSORS:-$(sysctl -n hw.ncpu)}"
 fi
 

--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -59,6 +59,8 @@ then
 elif [[ "$OSTYPE" == "darwin"* ]]
 then
 	export NPROCESSORS="${NPROCESSORS:-$(sysctl -n hw.ncpu)}"
+else
+	export NPROCESSORS="${NPROCESSORS:-1}"
 fi
 
 export SED="${SED:-sed}" CP="${CP:-cp}" RM="${RM:-rm}"
@@ -439,7 +441,6 @@ test|retest)
     echo "GregorioTeX = $(kpsewhich gregoriotex.tex)"
     echo
 
-    processors=$(nproc 2>/dev/null || echo 1)
     cd output
     if $progress_bar
     then

--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -36,6 +36,7 @@
 #                        into the filename of the actual result.
 # PDF_DENSITY   integer  the dpi to use for the pdf comparison.
 # SKIP_TESTS    array    tests to skip
+# NPROCESSORS   integer  number of processors available for running tests
 
 # for predictability in parsing results
 export LC_ALL=C
@@ -50,6 +51,12 @@ rcfile=gregorio-test.rc
 if [ -f $rcfile -a -r $rcfile ]
 then
     source $rcfile
+fi
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	export NPROCESSORS="${NPROCESSORS:-$(nproc)}"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	export NPROCESSORS="${NPROCESSORS:-$(sysctl -n hw.ncpu)}"
 fi
 
 export SED="${SED:-sed}" CP="${CP:-cp}" RM="${RM:-rm}"
@@ -454,7 +461,7 @@ test|retest)
         overall_result=0
         time for group in ${groups}
         do
-            if ! ${group}_find | filter | $XARGS -P $processors -n 1 -I{} bash -c "${group}_test"' "$@"' _ {} \;
+            if ! ${group}_find | filter | $XARGS -P $NPROCESSORS -n 1 -I{} bash -c "${group}_test"' "$@"' _ {} \;
             then
                 overall_result=1
             fi


### PR DESCRIPTION
An undefined variable `$processors` was being used to pass the number of processors to `xargs` in order to run multiple tests in parallel.  This change renames the variable to `$NPROCESSORS`, defines a default value (the number of addressable processors reported by the system) and allows the user to change that number with a setting in `gregorio-test.rc`

Addresses #321 