### PR TITLE
Differentiation error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 Each branch on this repository should correspond to the matching branch (i.e.
 the one with the same name) in the
 [main repository](https://github.com/gregorio-project/gregorio).  That is, all
-the tests should pass when run against that branch with TeXLive 2015.  Thus all
+the tests should pass when run against that branch with TeX Live 2018.  Thus all
 new development in the main repository should create a corresponding branch
 here.  The exception to this is a branch which should not break any existing
 test and requires no new tests.  In this instance, it's acceptable to simply
 indicate that all tests on the develop (or master) branch here should pass.
 
-### TeXLive 2014
+### Supplemental Fonts
 
-When testing with TeXLive 2014 the following tests are known to fail due to
+The `gabc-output/bar-substitution.gabc` test makes use of gregorio.ttf and thus
+will fail if the supplemental fonts are not installed.
+
+### TeX Live 2014
+
+When testing with TeX Live 2014 the following tests are known to fail due to
 differences between its line breaking algorithms and those in TeXLive 2015 and later:
   -`gabc-output/double-clef.gabc`
 

--- a/harness.sh
+++ b/harness.sh
@@ -526,7 +526,9 @@ function typeset_and_compare {
                                 failed[${#failed[@]}]="$indir/$outdir/$name"
                             fi
                         else
-                            failed[${#failed[@]}]="$indir/$outdir/$name"
+                            fail "Failed to find expectation image" \
+                                "$expected cannot be found"
+                            return
                         fi
                     done
                     if [ ${#failed[@]} != 0 ]

--- a/harness.sh
+++ b/harness.sh
@@ -490,7 +490,7 @@ function typeset_and_compare {
                 if $skip_cache || [[ "$pdffile" -nt "$directory" ]]
                 then
                     rm -fr "$directory" && \
-                    mkdir -p "$directory" && \
+                        mkdir -p "$directory" && \
                         convert -background white -alpha remove \
                             -colorspace Gray -channel R -separate \
                             -density $PDF_DENSITY "$pdffile" \

--- a/harness.sh
+++ b/harness.sh
@@ -485,14 +485,15 @@ function typeset_and_compare {
         else
             if $verify "$texfile"
             then
-                if $skip_cache || [[ "$pdffile" -nt "$IMAGE_CACHE/$indir/$outdir" ]]
+                directory="$IMAGE_CACHE/$indir/$outdir"
+                if $skip_cache || [[ "$pdffile" -nt "$directory" ]]
                 then
-                    rm -fr "$IMAGE_CACHE/$indir/$outdir" && \
-                    mkdir -p "$IMAGE_CACHE/$indir/$outdir" && \
+                    rm -fr "$directory" && \
+                    mkdir -p "$directory" && \
                         convert -background white -alpha remove \
                             -colorspace Gray -channel R -separate \
                             -density $PDF_DENSITY "$pdffile" \
-                            "$IMAGE_CACHE/$indir/$outdir/page-%d.png" || \
+                            "$directory/page-%d.png" || \
                         fail "Failed to create expectation images" \
                             "Failed to create images for $indir/$outdir/$pdffile"
                 fi
@@ -506,7 +507,7 @@ function typeset_and_compare {
                     declare -a failed
                     for name in page*.png
                     do
-                        expected="$IMAGE_CACHE/$indir/$outdir/$name"
+                        expected="$directory/$name"
                         if [ -f "$expected" ]
                         then
                             metric=$(compare -metric NCC \

--- a/harness.sh
+++ b/harness.sh
@@ -486,6 +486,7 @@ function typeset_and_compare {
             if $verify "$texfile"
             then
                 directory="$IMAGE_CACHE/$indir/$outdir"
+                not_nice=false
                 if $skip_cache || [[ "$pdffile" -nt "$directory" ]]
                 then
                     rm -fr "$directory" && \
@@ -494,8 +495,15 @@ function typeset_and_compare {
                             -colorspace Gray -channel R -separate \
                             -density $PDF_DENSITY "$pdffile" \
                             "$directory/page-%d.png" || \
+                        not_nice=true
+                    if $not_nice
+                    then
                         fail "Failed to create expectation images" \
                             "Failed to create images for $indir/$outdir/$pdffile"
+                        rm -fr "$directory"
+                        not_nice=false
+                        return
+                    fi
                 fi
 
                 if cd "$outdir" && \

--- a/harness.sh
+++ b/harness.sh
@@ -528,6 +528,10 @@ function typeset_and_compare {
                         else
                             fail "Failed to find expectation image" \
                                 "$expected cannot be found"
+                            if ! $skip_cache
+                            then
+                                echo "Try rebuilding image cache with -i"
+                            fi
                             return
                         fi
                     done


### PR DESCRIPTION
When an expectation image cannot be found the image comparison is skipped and the test fails.  Previously, however, this was reported as a "Results differ" failure, implying that the comparison was run.  This change makes it so that the reported error message indicates the real cause of the test failure (missing expectation image).