### PR TITLE
Test `\gresetgregpath`

### DIFF
--- a/tests/tex-output/per-line-spaces/PopulusSion.gabc
+++ b/tests/tex-output/per-line-spaces/PopulusSion.gabc
@@ -1,1 +1,0 @@
-../PopulusSion/PopulusSion.gabc

--- a/tests/tex-output/per-line-spaces/per-line-spaces.tex
+++ b/tests/tex-output/per-line-spaces/per-line-spaces.tex
@@ -56,6 +56,7 @@
 
 \grechangenextscorelinedim{2}{spacelinestext}{2cm}{scalable}
 
+\gresetgregpath{{../PopulusSion/}}
 % and finally we include the score. The file must be in the same directory as this one.
 \gregorioscore[a]{PopulusSion}
 


### PR DESCRIPTION
Instead of having an alias which translates into a copied file, the test is modified to borrow the gabc file from another test using the new `\gresetgregpath` mechanism.

Corresponds to gregorio-project/gregorio#1440