### PR TITLE
Refine kpse tests exit status

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -502,12 +502,18 @@ function scripted_test {
 
     if cd "$indir"
     then
-        if bash "$filename" >"$outfile" 2>"$logfile"
-        then
-            pass
-        else
-            fail "Failed to compile" "Failed to compile $filename"
-        fi
+        bash "$filename" >"$outfile" 2>"$logfile"
+        exit_status=$?
+        case $exit_status in
+            "0")
+                pass ;;
+            "1")
+                fail "Failed to compile" "Failed to compile $filename" ;;
+            "2")
+                echo "$gregorio does not use the kpathsea libraries$CLEAR_EOL"
+                echo "automatically passing $filename"
+                pass
+        esac
     else
         fail "Failed to create directory" "Could not change to $indir"
     fi

--- a/tests/scripted/cli/kpse_bad_in.sh
+++ b/tests/scripted/cli/kpse_bad_in.sh
@@ -6,5 +6,7 @@ then
     else exit 0
     fi
 else
+    >&2 echo "$gregorio does not use the kpathsea libraries"
+    >&2 echo "unable to run test kpse_bad_in.sh"
     exit 2
 fi

--- a/tests/scripted/cli/kpse_bad_in.sh
+++ b/tests/scripted/cli/kpse_bad_in.sh
@@ -6,5 +6,5 @@ then
     else exit 0
     fi
 else
-    exit 0
+    exit 2
 fi

--- a/tests/scripted/cli/kpse_bad_out.sh
+++ b/tests/scripted/cli/kpse_bad_out.sh
@@ -6,5 +6,5 @@ then
     else exit 0
     fi
 else
-    exit 0
+    exit 2
 fi

--- a/tests/scripted/cli/kpse_bad_out.sh
+++ b/tests/scripted/cli/kpse_bad_out.sh
@@ -6,5 +6,7 @@ then
     else exit 0
     fi
 else
+    >&2 echo "$gregorio does not use the kpathsea libraries"
+    >&2 echo "unable to run test kpse_bad_out.sh"
     exit 2
 fi

--- a/tests/scripted/cli/kpse_ok.sh
+++ b/tests/scripted/cli/kpse_ok.sh
@@ -4,5 +4,7 @@ then
     eval $gregorio -S test.gabc
     exit $?
 else
+    >&2 echo "$gregorio does not use the kpathsea libraries"
+    >&2 echo "unable to run test kpse_ok.sh"
     exit 2
 fi

--- a/tests/scripted/cli/kpse_ok.sh
+++ b/tests/scripted/cli/kpse_ok.sh
@@ -4,5 +4,5 @@ then
     eval $gregorio -S test.gabc
     exit $?
 else
-    exit 0
+    exit 2
 fi


### PR DESCRIPTION
If the version of Gregorio being tested doesn't make use of the kpathsea libriaries, then these tests are invalid tests, so the tests themselves should note that with their exit state. However, we don't want the tests to fail and clutter up the results, so we auto-pass them (just as before) but print a note about the autopass to the screen.