### PR TITLE
Remove deprecated count from gsptest

### DIFF
--- a/tests/tex-output/gsptest/gsp-sample.tex
+++ b/tests/tex-output/gsptest/gsp-sample.tex
@@ -54,8 +54,6 @@
 \grechangecount{endafterbarpenalty}{-200}%
 % penalty right after a bar with nothing printed
 \grechangecount{endafterbaraltpenalty}{-200}%
-% penalty at the end of the score
-\grechangecount{finalpenalty}{0}%
 % penalty at the end of a breakable neumatic element (typically at a space
 % between elements)
 \grechangecount{endofelementpenalty}{-50}%


### PR DESCRIPTION
This probably should have been removed in #374, the PR associated with the deprecation of `finalpenalty`.