### PR TITLE
Fix "Too many open files" error

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -17,11 +17,11 @@
 # ImageMagick changed the way it wants to be called starting from v7
 if [ -z "$CONVERT" ]; then
     if command -v magick >/dev/null 2>&1; then
-        export CONVERT=magick
-        export COMPARE="magick compare"
+        export CONVERT=$(which magick)
+        export COMPARE="$(which magick) compare"
     elif command -v convert >/dev/null 2>&1; then
-        export CONVERT=convert
-        export COMPARE=compare
+        export CONVERT=$(which convert)
+        export COMPARE=$(which compare)
     else
         echo "error: ImageMagick is not installed" 1>&2
         exit


### PR DESCRIPTION
In harness.sh, a shell function `compare` is defined that calls the program `compare`. Apparently in some shells this causes infinite recursion. A "too many open files" error is printed, but gets piped into `bc`, yielding cryptic output.

This happened to me in Ubuntu 24.04.4 LTS with bash 5.2.21(1)-release.

This commit fixes it by using an absolute path to the program `compare`.