### PR TITLE
Remove stray \r, if present

### DIFF
--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -396,7 +396,7 @@ test|retest)
 
     if [ "$gregorio_dir" = "" ]
     then
-        gregorio_version=$(grep 'FILENAME_VERSION' $(kpsewhich gregoriotex.lua))
+        gregorio_version=$(grep 'FILENAME_VERSION' $(kpsewhich gregoriotex.lua | sed 's/\r//'))
         gregorio_version=${gregorio_version#*\'gregorio-}
         gregorio_version=${gregorio_version%\'*}
     else


### PR DESCRIPTION
On Cygwin, there's an extra `\r` at the end of the output of `kpsewhich gregoriotex.lua`.  When fed into grep as part of the filename, this messes things up so that grep no longer understands the filename.  A simple pipe of the output to sed to remove the `\r` fixes the problem on Cygwin and doesn't harm macOS (which doesn't produce it in the first place).  Not tested under Linux, but I've never found Linux to differ from macOS on this sort of thing.