### PR TITLE
Options to view status of the most recent test run

### DIFF
--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -116,7 +116,7 @@ declare -A tests_to_run
 while (( $# > 0 ))
 do
     unset OPTIND
-    while getopts ":acCdD:eg:GhilLnPrSvmF" opt
+    while getopts ":acCdD:eg:GhilLnPrSvmFRA" opt
     do
         case $opt in
         a)
@@ -199,6 +199,12 @@ do
             ;;
         F)
             mode=failures
+            ;;
+        R)
+            mode=ran_tests
+            ;;
+        A)
+            mode=accepted
             ;;
         \?)
             echo "Unknown option: -$OPTARG" >&2
@@ -301,7 +307,11 @@ Options:
   
   -m                show the summary from the most recently run set of tests
   
-  -F                show the failed tests from the most recently run set of tests
+  -F                show the failed tests from the most recently run set of 
+                    tests
+  
+  -A                show tests whose results have been accepted from the most 
+                    recent run
 
   -h                shows this usage message.
 
@@ -372,7 +382,7 @@ source harness.sh
 
 # early exit modes
 case "$mode" in
-summary|failures)
+summary|failures|ran_tests|accepted)
     # warn if any test arguments were provided
     if [ "${#tests_to_run[@]}" -ne 0 ]; then
         echo "Warning: TEST arguments are ignored in $mode mode." >&2
@@ -396,6 +406,24 @@ summary|failures)
             echo "FAILED TESTS"
             echo "============"
             $FIND . -name '*.result' -exec grep '^FAIL|' {} + | \
+                while IFS='|' read -r status test message
+                do
+                    echo "$test : $message"
+                done
+            echo
+            exit 0
+            ;;
+        ran_tests)
+            echo "TESTS RUN"
+            echo "========="
+            $FIND . -name '*.result' -exec cut -d'|' -f2 {} + | sort | uniq
+            echo
+            exit 0
+            ;;
+        accepted)
+            echo "ACCEPTED TESTS"
+            echo "=============="
+            $FIND -name '*.result' -exec grep '^ACCEPT|' {} + | \
                 while IFS='|' read -r status test message
                 do
                     echo "$test : $message"

--- a/gregorio-test.sh
+++ b/gregorio-test.sh
@@ -22,6 +22,40 @@ export LC_ALL=C
 export testroot="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
 cd "$testroot"
 
+print_summary() {
+    total_count=0
+    fail_count=0
+    declare -A result_counts
+
+    while IFS="|" read -r result file message
+    do
+        ((++result_counts[$message]))
+        ((++total_count))
+
+        if [ "$result" = "FAIL" ]
+        then
+            ((++fail_count))
+        fi
+    done < <($FIND . -name '*.result' -exec cat {} +)
+
+    echo "SUMMARY"
+    echo "======="
+    for message in "${!result_counts[@]}"
+    do
+        echo "$message : ${result_counts[$message]}/$total_count"
+    done
+    echo
+
+    if [ "$fail_count" -ne 0 ]
+    then
+        echo "${C_BAD}SOMETHING FAILED${C_RESET}"
+        return 1
+    else
+        echo "${C_GOOD}ALL PASS${C_RESET}"
+        return 0
+    fi
+}
+
 VIEW_TEXT="cat {file}"
 DIFF_TEXT="diff {expect} {output}"
 
@@ -82,7 +116,7 @@ declare -A tests_to_run
 while (( $# > 0 ))
 do
     unset OPTIND
-    while getopts ":acCdD:eg:GhilLnPrSv" opt
+    while getopts ":acCdD:eg:GhilLnPrSvmF" opt
     do
         case $opt in
         a)
@@ -159,6 +193,12 @@ do
             ;;
         v)
             mode=view_output
+            ;;
+        m)
+            mode=summary
+            ;;
+        F)
+            mode=failures
             ;;
         \?)
             echo "Unknown option: -$OPTARG" >&2
@@ -258,6 +298,10 @@ Options:
                     tests.
 
   -i                do not use cached images when running comparisons
+  
+  -m                show the summary from the most recently run set of tests
+  
+  -F                show the failed tests from the most recently run set of tests
 
   -h                shows this usage message.
 
@@ -325,6 +369,43 @@ then
 fi
 
 source harness.sh
+
+# early exit modes
+case "$mode" in
+summary|failures)
+    # warn if any test arguments were provided
+    if [ "${#tests_to_run[@]}" -ne 0 ]; then
+        echo "Warning: TEST arguments are ignored in $mode mode." >&2
+        echo
+    fi
+    
+    if [ ! -d output ]
+    then
+        echo "No previous run found." >&2
+        exit 9
+    fi
+
+    cd output || exit 9
+
+    case "$mode" in
+        summary)
+            print_summary
+            exit $?
+            ;;
+        failures)
+            echo "FAILED TESTS"
+            echo "============"
+            $FIND . -name '*.result' -exec grep '^FAIL|' {} + | \
+                while IFS='|' read -r status test message
+                do
+                    echo "$test : $message"
+                done
+            echo
+            exit 0
+            ;;
+    esac
+    ;;
+esac
 
 if [ ! -d tests ]
 then
@@ -518,37 +599,10 @@ test|retest)
         done
     fi
     wait $!
-    overall_result=$?
-
-    $FIND . -name '*.result' -exec cat {} + | {
-        total_count=0
-        declare -A result_counts
-        old_IFS="$IFS"
-        IFS="|"
-        while read result file message
-        do
-            ((++result_counts[$message]))
-            ((++total_count))
-        done
-        IFS="$old_IFS"
-        echo
-        echo "SUMMARY"
-        echo "======="
-        for message in "${!result_counts[@]}"
-        do
-            echo "$message" : "${result_counts[$message]}/$total_count"
-        done
-    }
-
+    
     echo
-
-    if [ ${overall_result} != 0 ]
-    then
-        echo "${C_BAD}SOMETHING FAILED${C_RESET}"
-        exit 1
-    fi
-
-    echo "${C_GOOD}ALL PASS${C_RESET}"
+    print_summary
+    overall_result=$?
     ;;
 accept|view_*)
     cd output

--- a/harness.sh
+++ b/harness.sh
@@ -153,6 +153,8 @@ function maybe_run {
 
 function accept_result {
     echo "Accepting $2 as expectation for $1"
+    
+    # Decide where to copy the accepted file
     if [[ "$1" = *"_B"* ]]
     then
         # this is a backwards test so it needs to be copied to backwards not tests
@@ -160,7 +162,18 @@ function accept_result {
     else
         accept_dest="tests"
     fi
+
+    # Copy new output to tests/backwards folder
     $CP "$2" "$testroot/$accept_dest/$(dirname "$1")/$3"
+
+    # Update the result status in the corresponding .result file
+    result_file="$testroot/output/$1.result"
+    if [ -f "$result_file" ]; then
+        $SED -i.bak 's/^FAIL|/ACCEPT|/' "$result_file"
+        rm -f "$result_file.bak"   # optional: remove backup
+    else
+        echo "Warning: .result file not found for $1" >&2
+    fi
 }
 
 function view_text {
@@ -544,7 +557,18 @@ function scripted_clean {
     true
 }
 function scripted_accept {
-    echo "Nothing to accept"
+    echo "Marking as accepted"
+    echo "Note: This does not make any changes to the test"
+    echo "      You must do that manually"
+
+    # Update the result status in the corresponding .result file
+    result_file="$testroot/output/$1.result"
+    if [ -f "$result_file" ]; then
+        $SED -i.bak 's/^FAIL|/ACCEPT|/' "$result_file"
+        rm -f "$result_file.bak"   # optional: remove backup
+    else
+        echo "Warning: .result file not found for $1" >&2
+    fi
 }
 function scripted_view_log {
     view_text "${1%.sh}.log"


### PR DESCRIPTION
Fixes #333.

This adds 4 options to gregorio-test.sh:
1) `-m`: View the summary of the most recent test run
2) `-F`: View the list of tests which failed in the most recent test run and which have not yet been accepted
3) `-R`: View the full list of tests which were run in the last test run
4) `-A`: View the list of tests which have had their new results accepted since the last test run (Note: for the scripted tests, "accepting" a test result now marks the test as accepted, but still does not actually change anything about the test.  A warning to this effect is printed when such a test is marked as accepted.)

I've tested this on both macOS and Cygwin.